### PR TITLE
Make reflection into JEI more resiliant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,12 +141,10 @@ dependencies {
     minecraft "net.minecraftforge:forge:${forge_version}"
 
     // compile against the JEI API but do not include it at runtime
-//    compileOnly fg.deobf("mezz.jei:jei-${mc_version}-common-api:${jei_version}")
-//    compileOnly fg.deobf("mezz.jei:jei-${mc_version}-common:${jei_version}")
     // at runtime, use the full JEI jar for Forge
     runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}")
-    // Need to compile full JEI because api is missing IngredientListOverlay
-    compileOnly fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${mc_version}-common-api:${jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${mc_version}-forge-api:${jei_version}")
 
     //provided files("libs/CustomMobSpawner-3.11.4.jar")
 

--- a/src/main/java/at/ridgo8/moreoverlays/itemsearch/JeiModule.java
+++ b/src/main/java/at/ridgo8/moreoverlays/itemsearch/JeiModule.java
@@ -1,21 +1,20 @@
 package at.ridgo8.moreoverlays.itemsearch;
 
 import at.ridgo8.moreoverlays.MoreOverlays;
+import at.ridgo8.moreoverlays.util.ReflectionUtil;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.helpers.IJeiHelpers;
-import mezz.jei.api.registration.IAdvancedRegistration;
+import mezz.jei.api.ingredients.subtypes.UidContext;
+import mezz.jei.api.registration.IRecipeCategoryRegistration;
 import mezz.jei.api.runtime.IIngredientFilter;
 import mezz.jei.api.runtime.IIngredientListOverlay;
 import mezz.jei.api.runtime.IJeiRuntime;
-import mezz.jei.gui.overlay.IngredientListOverlay;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
-import mezz.jei.api.ingredients.subtypes.UidContext;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Field;
 
 @JeiPlugin
 public class JeiModule implements IModPlugin {
@@ -23,31 +22,16 @@ public class JeiModule implements IModPlugin {
     public static IIngredientListOverlay overlay;
     public static IIngredientFilter filter;
     private static IJeiHelpers jeiHelpers;
-    private static IngredientListOverlay overlayInternal;
     private static EditBox textField;
 
     public static void updateModule() {
-        if (overlay instanceof IngredientListOverlay) {
-            overlayInternal = ((IngredientListOverlay) overlay);
-            try {
-                Field searchField = IngredientListOverlay.class.getDeclaredField("searchField");
-                searchField.setAccessible(true);
-                textField = (EditBox) searchField.get(overlayInternal);
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                try {
-                    // If JEI decides to change it to textFieldFilter
-                    Field searchField = IngredientListOverlay.class.getDeclaredField("textFieldFilter");
-                    searchField.setAccessible(true);
-                    textField = (EditBox) searchField.get(overlayInternal);
-                } catch (NoSuchFieldException | IllegalAccessException f) {
-                    MoreOverlays.logger.error("Something went wrong. Tried to load JEI Search Text Field object");
-                    e.printStackTrace();
-                    f.printStackTrace();
-                }
-            }
-        } else{
-            overlayInternal = null;
-            textField = null;
+        if (overlay != null) {
+            textField = ReflectionUtil.findFieldsWithClass(overlay, EditBox.class)
+                .findFirst()
+                .orElseGet(() -> {
+                    MoreOverlays.logger.error("Something went wrong. Could not find JEI Search Text Field object");
+                    return null;
+                });
         }
     }
 
@@ -60,15 +44,6 @@ public class JeiModule implements IModPlugin {
             return ItemUtils.matchNBT(stack1, stack2);
         }
         return jeiHelpers.getStackHelper().isEquivalent(stack1, stack2, UidContext.Ingredient);
-
-		/*
-		String info1 = subtypes.getSubtypeInfo(stack1);
-		String info2 = subtypes.getSubtypeInfo(stack2);
-		if (info1 == null || info2 == null) {
-			return ItemUtils.matchNBT(stack1, stack2);
-		} else {
-			return info1.equals(info2);
-		}*/
     }
 
     @Override
@@ -79,11 +54,12 @@ public class JeiModule implements IModPlugin {
     }
 
     @Override
-    public void registerAdvanced(IAdvancedRegistration registration) {
+    public void registerCategories(@Nonnull IRecipeCategoryRegistration registration) {
         jeiHelpers = registration.getJeiHelpers();
     }
 
     @Override
+    @Nonnull
     public ResourceLocation getPluginUid() {
         return new ResourceLocation(MoreOverlays.MOD_ID, "jei_module");
     }

--- a/src/main/java/at/ridgo8/moreoverlays/itemsearch/JeiModule.java
+++ b/src/main/java/at/ridgo8/moreoverlays/itemsearch/JeiModule.java
@@ -32,6 +32,8 @@ public class JeiModule implements IModPlugin {
                     MoreOverlays.logger.error("Something went wrong. Could not find JEI Search Text Field object");
                     return null;
                 });
+        } else {
+            textField = null;
         }
     }
 

--- a/src/main/java/at/ridgo8/moreoverlays/util/ReflectionUtil.java
+++ b/src/main/java/at/ridgo8/moreoverlays/util/ReflectionUtil.java
@@ -1,0 +1,54 @@
+package at.ridgo8.moreoverlays.util;
+
+import at.ridgo8.moreoverlays.MoreOverlays;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Adapted from the version in JEI under the MIT license.
+ * <a href="https://github.com/mezz/JustEnoughItems/blob/15bbaa4f8db1d77cf7ddd99178ffcd22dc20bd89/Core/src/main/java/mezz/jei/core/util/ReflectionUtil.java">ReflectionUtil.java</a>
+ * @author mezz
+ */
+public final class ReflectionUtil {
+	public static <T> Stream<T> findFieldsWithClass(Object object, Class<? extends T> fieldClass) {
+		return getAllFields(object)
+			.filter(field -> fieldClass.isAssignableFrom(field.getType()))
+			.mapMulti((field, mapper) -> {
+				try {
+					field.setAccessible(true);
+					Object fieldValue = field.get(object);
+					if (fieldClass.isInstance(fieldValue)) {
+						T cast = fieldClass.cast(fieldValue);
+						mapper.accept(cast);
+					}
+				} catch (IllegalAccessException | InaccessibleObjectException | SecurityException e) {
+					MoreOverlays.logger.error("Something went wrong. Failed to get field " + fieldClass, e);
+				}
+			});
+	}
+
+	private static Stream<Field> getAllFields(Object object) {
+		Class<?> objectClass = object.getClass();
+		List<Class<?>> classes = new ArrayList<>();
+		while (objectClass != Object.class) {
+			classes.add(objectClass);
+			objectClass = objectClass.getSuperclass();
+		}
+
+		return classes.stream()
+			.flatMap(c -> {
+				try {
+					Field[] fields = c.getDeclaredFields();
+					return Arrays.stream(fields);
+				} catch (SecurityException e) {
+					MoreOverlays.logger.error("Something went wrong. Failed to get fields on " + c, e);
+					return Stream.of();
+				}
+			});
+	}
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/mezz/JustEnoughItems/issues/3064

I was thinking about adding the edit box in the API, but I realized that what More Overlays wants to do with it is actually really hacky. I don't really want to encourage other mods to use the search bar directly, they may misunderstand why I am exposing it to the API and do something weird by accident.

This PR adds a function that uses reflection to find the EditBox without caring about the field's name. It'll just search through all the fields and pick the first EditBox field. I think that will be safer against renames or class name changes in the future, and it allows MoreOverlays to work without compiling against JEI's internals.